### PR TITLE
Fixed Missing Case - old Unknown event: 20

### DIFF
--- a/Arduino/nRF52840_LoRaWAN_Test/nRF52840_LoRaWAN_Test.ino
+++ b/Arduino/nRF52840_LoRaWAN_Test/nRF52840_LoRaWAN_Test.ino
@@ -88,6 +88,9 @@ void onEvent (ev_t ev) {
     case EV_LINK_ALIVE:
       Serial.println(F("EV_LINK_ALIVE"));
       break;
+    case EV_JOIN_TXCOMPLETE:
+      Serial.println(F("EV_JOIN_TXCOMPLETE: no JoinAccept"));
+      break;
     default:
       Serial.print(F("Unknown event: "));
       Serial.println((unsigned) ev);


### PR DESCRIPTION
This Error get thrown when the LoRa Device can't join - e.g. forced by a user in this topic: https://github.com/mcci-catena/arduino-lmic/issues/542#issuecomment-587171606